### PR TITLE
Share the tailscaled socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,32 @@ The snap is strictly confined, and requires the following interfaces:
 - [network-control](https://snapcraft.io/docs/network-control-interface): required for configuring the network and access to /dev/net/tun. Tailscaled needs this to set up networking rules for the wiregard config and such (routing, attaching networks, etc.).
 - `sys-devices-virtual-info`: a custom [system-files](https://snapcraft.io/docs/system-files-interface) read-only interface for files tailscaled needs to determine the platform it's running on.
 
+
+## Integration with other snaps
+
+Other snaps can access tailscaled via its unix socket through the `tailscale:socket` slot.
+This slot exposes a content interface, which will be a directory containing the `tailscaled.sock` socket file.
+
+For example, if there is a snap called `derper`,
+and it has this plug definition:
+
+```
+plugs:
+  tailscale-socket:
+    interface: content
+    content: socket-directory
+    target: $SNAP_DATA/tailscale-socket
+```
+
+Then you can integrate `derper` with `tailscale` like this:
+
+```
+$ sudo snap connect derper:tailscale-socket tailscale:socket
+```
+
+And the tailscaled socket will be available to the `derper` snap
+as `$SNAP_DATA/tailscale-socket/tailscaled.sock`.
+
 ## License
 
 This packaging repository is released under the BSD 3-Clause "New" or "Revised" license.

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+# Ensure the custom socket dir exists.
+# This is shared on a content interface so that compatible snaps can access the tailscale socket if needed.
+mkdir -p $SNAP_DATA/socket

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,14 +40,23 @@ plugs:
       - /sys/devices/virtual/dmi/id/product_name
       - /sys/devices/virtual/dmi/id/sys_vendor
 
+slots:
+  # Share the socket directory to support the case where another snap needs to communicate with tailscaled.
+  socket:
+    interface: content
+    content: writable-data
+    write:
+      - $SNAP_DATA/socket
+
 apps:
   tailscale:
-    command: bin/tailscale
+    command: bin/tailscale --socket $SNAP_DATA/socket/tailscaled.sock
     plugs:
       - network
       - network-bind
   tailscaled:
-    command: bin/tailscaled --statedir $SNAP_DATA --verbose 10
+    # NOTE: cannot use layout to support default socket location, because /var/run is not allowed for layout.
+    command: bin/tailscaled --socket $SNAP_DATA/socket/tailscaled.sock --statedir $SNAP_DATA --verbose 10
     daemon: simple
     plugs:
       - firewall-control
@@ -67,8 +76,6 @@ parts:
       - iptables
       - openssh-client  # for tailscale ssh
     override-build: |
-      # Tailscaled socket path is hardcoded, so it must be patched here to work in the snap environment.
-      sed -i paths/paths.go -e 's|"/var/run/tailscale/tailscaled.sock"|filepath.Join(os.Getenv("SNAP_DATA"), "tailscaled.sock")|'
       go install -p $CRAFT_PARALLEL_BUILD_COUNT ./cmd/tailscale
       go install -p $CRAFT_PARALLEL_BUILD_COUNT ./cmd/tailscaled
     override-prime: |


### PR DESCRIPTION
This supports there case where other snaps, such as derper,
may need to integrate with tailscaled via its unix socket.

See also https://github.com/canonical/derper-snap/pull/4