### PR TITLE
Remove untested architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,8 +25,6 @@ description: |
 
 platforms:
   amd64:
-  arm64:
-  armhf:
 
 plugs:
   sys-devices-virtual-dmi-ids:


### PR DESCRIPTION
Our automation and testing has only covered amd64 so far. We can add other architectures in the future.
But for now, remove them from snapcraft.yaml to avoid confusion.