### PR TITLE
Move socket to SNAP_COMMON

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ plugs:
   tailscale-socket:
     interface: content
     content: socket-directory
-    target: $SNAP_DATA/tailscale-socket
+    target: $SNAP_COMMON/tailscale-socket
 ```
 
 Then you can integrate `derper` with `tailscale` like this:
@@ -65,7 +65,7 @@ $ sudo snap connect derper:tailscale-socket tailscale:socket
 ```
 
 And the tailscaled socket will be available to the `derper` snap
-as `$SNAP_DATA/tailscale-socket/tailscaled.sock`.
+as `$SNAP_COMMON/tailscale-socket/tailscaled.sock`.
 
 ## License
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -2,4 +2,4 @@
 
 # Ensure the custom socket dir exists.
 # This is shared on a content interface so that compatible snaps can access the tailscale socket if needed.
-mkdir -p $SNAP_DATA/socket
+mkdir -p $SNAP_COMMON/socket

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,17 +70,17 @@ slots:
     interface: content
     content: writable-data
     write:
-      - $SNAP_DATA/socket
+      - $SNAP_COMMON/socket
 
 apps:
   tailscale:
-    command: bin/tailscale --socket $SNAP_DATA/socket/tailscaled.sock
+    command: bin/tailscale --socket $SNAP_COMMON/socket/tailscaled.sock
     plugs:
       - network
       - network-bind
   tailscaled:
     # NOTE: cannot use layout to support default socket location, because /var/run is not allowed for layout.
-    command: bin/tailscaled --socket $SNAP_DATA/socket/tailscaled.sock --statedir $SNAP_DATA --verbose 10
+    command: bin/tailscaled --socket $SNAP_COMMON/socket/tailscaled.sock --statedir $SNAP_COMMON --verbose 10
     daemon: simple
     plugs:
       - firewall-control


### PR DESCRIPTION
With the file in SNAP_DATA - the directory that is versioned along with snap revisions - we have the situation where if we update the snap, the new tailscale client will look for the socket at the new revision path. If we didn't restart tailscale (which we may not want to do), it will still be at the old revision, therefore the new tailscale binary can't find it's socket. This is undesirable, as there may be cases where the user wishes to refresh the snap without restarting the service right away.

