### PR TITLE
Add arm64 support to the snap

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [[ubuntu-22.04]]
+        runs-on: [[ubuntu-22.04], [self-hosted, jammy, ARM64]]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [[ubuntu-22.04]]
+        runs-on: [[ubuntu-22.04], [self-hosted, jammy, ARM64]]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [[ubuntu-22.04]]
+        runs-on: [[ubuntu-22.04], [self-hosted, jammy, ARM64]]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,6 +51,7 @@ description: |
 
 platforms:
   amd64:
+  arm64:
 
 plugs:
   sys-devices-virtual-dmi-ids:


### PR DESCRIPTION
- add arm64 to the snapcraft.yaml platforms
- include arm64 in the workflows