### PR TITLE
Update to upstream tailscale 1.78.3

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: tailscale
 base: core24
-version: 1.76.6
+version: 1.78.3
 license: BSD-3-Clause
 grade: stable
 confinement: strict


### PR DESCRIPTION
Update to the latest Tailscale release available at time of writing.

Fixes: #35