### PR TITLE
Add warning about running the manual tests

### DIFF
--- a/docs/manual-testing-playbook.md
+++ b/docs/manual-testing-playbook.md
@@ -10,6 +10,13 @@ you should be able to follow the document,
 running the snippets in order,
 to verify everything described here.
 
+> [!WARNING]
+> Be careful which account and tailnet you use for testing.
+> The test instructions include adding machines
+> and changing tailnet settings which may impact functionality or security compliance.
+> It's not recommended to run this testing on a production tailnet.
+
+
 ## Setup
 
 ### Prerequisites


### PR DESCRIPTION
We should be clear that the manual tests shouldn't be run on a production tailnet.