### PR TITLE
Add warning when refreshing the snap

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,11 @@
+#!/bin/sh -e
+
+cat <<EOF
+Tailscale has been updated,
+but the previous revision of the Tailscale service is still running.
+
+Please manually restart the service when convenient.
+WARNING: this may cause temporary network disruptions as the service restarts.
+
+$ sudo snap restart tailscale
+EOF


### PR DESCRIPTION
The snap service is not restarted automatically.