### PR TITLE
Revert "Don't restart service on snap refresh (#44)"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,13 +15,6 @@ description: |
 
   After installing this snap, visit the Tailscale documentation at https://tailscale.com/kb/1017/install to get started.
 
-  Since restarting the Tailscale service may result in network interruptions,
-  the service is not restarted on snap refresh.
-  This lets you control when the service restarts.
-  You must manually restart with `sudo snap restart tailscale`
-  at your convenience after refreshing the snap,
-  to start the new version running.
-
   **Confinement**
 
   The snap is strictly confined, and this currently brings some limitations.
@@ -90,10 +83,6 @@ apps:
     # NOTE: cannot use layout to support default socket location, because /var/run is not allowed for layout.
     command: bin/tailscaled --socket $SNAP_COMMON/socket/tailscaled.sock --statedir $SNAP_COMMON --verbose 10
     daemon: simple
-    # Don't restart the service on snap refresh.
-    # Restarting tailscaled could cause network interruptions,
-    # so let the user control when to restart.
-    refresh-mode: endure
     plugs:
       - firewall-control
       - network


### PR DESCRIPTION
After some discussion, we determined that restarting the service automatically when the snap refreshes has two major advantages:

1. It fits better with the standard expectation of services with snaps (and other system packages) - if the package is upgraded, the expectation is that automatically managed services are also upgraded.
2. It's better for security, because we avoid the situation where the snap has been refreshed to fix a security issue, but the old revision of tailscaled is still running.

This reverts commit 05df0fa0a6d9b21ba1d94175fef79081fda86920.