### PR TITLE
Build for prod to improve tailscale version output

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -101,8 +101,8 @@ parts:
       - iptables
       - openssh-client  # for tailscale ssh
     override-build: |
-      go install -p $CRAFT_PARALLEL_BUILD_COUNT ./cmd/tailscale
-      go install -p $CRAFT_PARALLEL_BUILD_COUNT ./cmd/tailscaled
+      ./build_dist.sh -p $CRAFT_PARALLEL_BUILD_COUNT -o $CRAFT_PART_INSTALL/bin/ ./cmd/tailscale
+      ./build_dist.sh -p $CRAFT_PARALLEL_BUILD_COUNT -o $CRAFT_PART_INSTALL/bin/ ./cmd/tailscaled
     override-prime: |
       craftctl default
       ln -s xtables-nft-multi $CRAFT_PRIME/usr/sbin/iptables


### PR DESCRIPTION
By using the upstream production build script,
we get a neater version output from `tailscale version`.

Before (note the `-dev20241211` postfix):

```
$ tailscale version --daemon --upstream
Client: 1.78.3-dev20241211
  tailscale commit: 1b41fdeddb6598b35ba15cc6b07740e0cc0e8411
  go version: go1.23.4
Daemon: 1.78.3-dev20241211-t1b41fdedd
Upstream: 1.80.0
```

Now with this patch:

```
$ tailscale version --daemon --upstream
Client: 1.78.3
  tailscale commit: 1b41fdeddb6598b35ba15cc6b07740e0cc0e8411
  go version: go1.23.5
Daemon: 1.78.3-t1b41fdedd
Upstream: 1.80.0
```

Fixes: #51