### PR TITLE
Remove openssh-client from dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -99,7 +99,6 @@ parts:
       - go
     stage-packages:
       - iptables
-      - openssh-client  # for tailscale ssh
     override-build: |
       ./build_dist.sh -p $CRAFT_PARALLEL_BUILD_COUNT -o $CRAFT_PART_INSTALL/bin/ ./cmd/tailscale
       ./build_dist.sh -p $CRAFT_PARALLEL_BUILD_COUNT -o $CRAFT_PART_INSTALL/bin/ ./cmd/tailscaled


### PR DESCRIPTION
This was originally there for `tailscale ssh` support, but `tailscale ssh` support was not added in the end because it requires too many permissions to justify the convenience,
including access to the user's ssh keys.