### PR TITLE
Remove manual installation of iptables

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -97,12 +97,6 @@ parts:
     plugin: go
     build-snaps:
       - go
-    stage-packages:
-      - iptables
     override-build: |
       ./build_dist.sh -p $CRAFT_PARALLEL_BUILD_COUNT -o $CRAFT_PART_INSTALL/bin/ ./cmd/tailscale
       ./build_dist.sh -p $CRAFT_PARALLEL_BUILD_COUNT -o $CRAFT_PART_INSTALL/bin/ ./cmd/tailscaled
-    override-prime: |
-      craftctl default
-      ln -s xtables-nft-multi $CRAFT_PRIME/usr/sbin/iptables
-      ln -s xtables-nft-multi $CRAFT_PRIME/usr/sbin/ip6tables


### PR DESCRIPTION
Manually installing iptables here is unnecessary,
as the firewall-control interface provides access
to the system iptables command already available.
Note that because this is the system iptables command shipped with the base snap (core24),
it still works even if iptables is not installed on the host.

ref. firewall-control interface definitions https://github.com/canonical/snapd/blob/80568f15a7c3f8429179ba77581e215cbef756cf/interfaces/builtin/firewall_control.go#L61-L64