### PR TITLE
fix(apparmor): allow /usr/bin/login exec and SSH host key read for Tailscale SSH in snap confinement

### DIFF
--- a/snap/hooks/security-override.apparmor
+++ b/snap/hooks/security-override.apparmor
@@ -1,0 +1,5 @@
+# Allow tailscaled to execute /usr/bin/login for Tailscale SSH
+/usr/bin/login Px,
+
+# Allow reading SSH host keys (if needed)
+/etc/ssh/ssh_host_*_key r,

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,6 +37,9 @@ description: |
 
   This snap is maintained by Canonical, and is not necessarily endorsed or officially maintained by the upstream developers.
 
+# AppArmor override for Tailscale SSH support:
+# See snap/hooks/security-override.apparmor for custom AppArmor rules to allow /usr/bin/login execution and SSH host key access.
+
 platforms:
   amd64:
   arm64:


### PR DESCRIPTION
## Problem
Tailscale SSH sessions fail when using the Snap package on Ubuntu 24.04 LTS due to AppArmor denials. Specifically, the confined tailscaled process is not permitted to execute, which is required to spawn a user shell after authentication. This results in SSH connections being closed immediately after authentication, with errors such as "operation not permitted" or "permission denied." AppArmor also blocks access to system SSH host keys, which may be required for full SSH functionality.

## Solution
This PR introduces a custom AppArmor override with the following rules:

Allow tailscaled to execute (Px permission).
Allow read access to /etc/ssh/ssh_host_*_key files.
These changes enable Tailscale SSH to function correctly under Snap confinement by permitting the necessary operations.

## Files Changed
New file with AppArmor rules for Tailscale SSH.
Added a reference comment for maintainers regarding the AppArmor override.

### Testing
Install the snap built from this branch.
Enable Tailscale SSH and attempt to SSH into the machine via Tailscale.
Confirm that an interactive shell is established and no AppArmor denials occur for or SSH host key access.

## Notes
This change is required for Tailscale SSH support in strictly confined snaps.
See related discussion: [Reported Issue](https://github.com/canonical/tailscale-snap/issues/77)

