### PR TITLE
enhance-e2e-testing

### DIFF
--- a/docs/e2e-testing-headscale-derper-tailscale.md
+++ b/docs/e2e-testing-headscale-derper-tailscale.md
@@ -35,6 +35,36 @@ cd docs
 terraform apply -var "ssh_key=YOUR PUBLIC SSH KEY CONTENTS"
 ```
 
+> **Note 1**:
+>If you encounter errors related to resource name uniqueness, the error message will include details such as:
+>```text
+>│ Error: updating Public I P Address (Subscription: "466ee356-ce1f-11ef-bf94-db2a042e145c"
+>│ Resource Group Name: "tailscale"
+>│ Public I P Addresses Name: "derper"): performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with error:
+>DnsRecordIsReserved: DNS record derper.australiaeast.cloudapp.azure.com is already reserved by another resource.
+>```
+>then this means the domain name is already taken. You will need to provide a unique dns prefix variable to terraform like so:
+>```bash
+>terraform destroy -auto-approve # destroy previous failed attempt
+>terraform apply \
+>    -var "ssh_key=YOUR PUBLIC SSH KEY CONTENTS" \
+>    -var "dns_prefix=YOUR_UNIQUE_PREFIX"
+>```
+>After this, the headscale and derper domain names will be prefixed with `YOUR_UNIQUE_PREFIX-`.
+>For example, if `dns_prefix=test123`, then the derper domain name will be `test123-derper.australiaeast.cloudapp.azure.com`
+>and headscale domain name will be `test123-headscale.australiaeast.cloudapp.azure.com`. **You will need to update any references to these domain names in the rest of this document accordingly**.
+>
+
+>**Note 2**:
+>The default VM size used is a lightweight [`Standard_B1s`](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/bv1-series). If you want to use a different VM size, you can provide the `vm_size` variable, for example to use the `Standard_DS1_v2`:
+>
+>```bash
+>terraform apply \
+>    -var="ssh_key=YOUR PUBLIC SSH KEY CONTENTS" \
+>    -var="vm_size=Standard_DS1_v2"
+>```
+>
+
 Terraform will output an ssh config snippet,
 with the configuration required to be able to ssh to the machines.
 Please copy this to your ssh config in order to connect to the machines for the rest of the steps.

--- a/docs/e2e.tf
+++ b/docs/e2e.tf
@@ -19,6 +19,18 @@ variable "ssh_key" {
   description = "public ssh key to be added to all created VMs (for the 'ubuntu' user)"
 }
 
+variable "dns_prefix" {
+  type        = string
+  description = "unique prefix for DNS labels to avoid conflicts in public domain names"
+  default     = ""
+}
+
+variable "vm_size" {
+  type        = string
+  description = "Azure VM size to use for all VMs"
+  default     = "Standard_B1s"
+}
+
 resource "azurerm_resource_group" "tailscale_testing" {
   name     = "tailscale"
   location = "Australia East"
@@ -52,11 +64,9 @@ resource "azurerm_subnet" "vnet_subnet_2" {
   address_prefixes     = ["10.1.2.0/24"]
 }
 
-# TODO: these domain names are public (derper and headscale) so there is chance of conflict if two people deploy this testing simultaneously or simply the domain name is taken - maybe these should be variables for this document and terraform?
-
 resource "azurerm_public_ip" "derper" {
   name                = "derper"
-  domain_name_label   = "derper"
+  domain_name_label   = var.dns_prefix != "" ? "${var.dns_prefix}-derper" : "derper"
   resource_group_name = azurerm_resource_group.tailscale_testing.name
   location            = azurerm_resource_group.tailscale_testing.location
   allocation_method   = "Static"
@@ -162,7 +172,7 @@ resource "azurerm_linux_virtual_machine" "derper" {
   name                = "derper"
   resource_group_name = azurerm_resource_group.tailscale_testing.name
   location            = azurerm_resource_group.tailscale_testing.location
-  size                = "Standard_DS1_v2"
+  size                = var.vm_size
   admin_username      = "ubuntu"
   network_interface_ids = [
     azurerm_network_interface.derper.id,
@@ -189,7 +199,7 @@ resource "azurerm_linux_virtual_machine" "derper" {
 
 resource "azurerm_public_ip" "headscale" {
   name                = "headscale"
-  domain_name_label   = "headscale"
+  domain_name_label   = var.dns_prefix != "" ? "${var.dns_prefix}-headscale" : "headscale"
   resource_group_name = azurerm_resource_group.tailscale_testing.name
   location            = azurerm_resource_group.tailscale_testing.location
   allocation_method   = "Static"
@@ -259,7 +269,7 @@ resource "azurerm_linux_virtual_machine" "headscale" {
   name                = "headscale"
   resource_group_name = azurerm_resource_group.tailscale_testing.name
   location            = azurerm_resource_group.tailscale_testing.location
-  size                = "Standard_DS1_v2"
+  size                = var.vm_size
   admin_username      = "ubuntu"
   network_interface_ids = [
     azurerm_network_interface.headscale.id,
@@ -355,7 +365,7 @@ resource "azurerm_linux_virtual_machine" "tailscale_jumpbox_1" {
   name                = "tailscale-jumpbox-1"
   resource_group_name = azurerm_resource_group.tailscale_testing.name
   location            = azurerm_resource_group.tailscale_testing.location
-  size                = "Standard_DS1_v2"
+  size                = var.vm_size
   admin_username      = "ubuntu"
   network_interface_ids = [
     azurerm_network_interface.tailscale_jumpbox_1.id,
@@ -384,7 +394,7 @@ resource "azurerm_linux_virtual_machine" "tailscale_jumpbox_2" {
   name                = "tailscale-jumpbox-2"
   resource_group_name = azurerm_resource_group.tailscale_testing.name
   location            = azurerm_resource_group.tailscale_testing.location
-  size                = "Standard_DS1_v2"
+  size                = var.vm_size
   admin_username      = "ubuntu"
   network_interface_ids = [
     azurerm_network_interface.tailscale_jumpbox_2.id,
@@ -429,7 +439,7 @@ resource "azurerm_linux_virtual_machine" "internal_1" {
   name                = "internal-1"
   resource_group_name = azurerm_resource_group.tailscale_testing.name
   location            = azurerm_resource_group.tailscale_testing.location
-  size                = "Standard_DS1_v2"
+  size                = var.vm_size
   admin_username      = "ubuntu"
   network_interface_ids = [
     azurerm_network_interface.internal_1.id,
@@ -474,7 +484,7 @@ resource "azurerm_linux_virtual_machine" "user_1" {
   name                = "user-1"
   resource_group_name = azurerm_resource_group.tailscale_testing.name
   location            = azurerm_resource_group.tailscale_testing.location
-  size                = "Standard_DS1_v2"
+  size                = var.vm_size
   admin_username      = "ubuntu"
   network_interface_ids = [
     azurerm_network_interface.user_1.id,
@@ -519,7 +529,7 @@ resource "azurerm_linux_virtual_machine" "user_2" {
   name                = "user-2"
   resource_group_name = azurerm_resource_group.tailscale_testing.name
   location            = azurerm_resource_group.tailscale_testing.location
-  size                = "Standard_DS1_v2"
+  size                = var.vm_size
   admin_username      = "ubuntu"
   network_interface_ids = [
     azurerm_network_interface.user_2.id,


### PR DESCRIPTION
1. Add an option in [e2e.tf](https://github.com/canonical/tailscale-snap/blob/292e03b8ee2485280a8422ccb429b80358ac7845/docs/e2e.tf) to allow user provide a prefix to the default DNS name to avoid public domain name conflict from `derper` and `headscale` machines. 
For example if `qn24` is the provided prefix, the DNS name for derper machine will be `qn24-derper.australiaeast.cloudapp.azure.com` instead of the default `derper.australiaeast.cloudapp.azure.com`:
<img width="296" height="324" alt="image" src="https://github.com/user-attachments/assets/65bf86ac-8ce0-4bc0-8a3a-e84da3655d43" />

An example conflict is updated in the doc with provided resolution.

2.Add an option in [e2e.tf](https://github.com/canonical/tailscale-snap/blob/292e03b8ee2485280a8422ccb429b80358ac7845/docs/e2e.tf) to decide the VM size instead of hardcoding, and change the default size to a more lightweight one, as the current one isn't supported in the provided region. 

Closes #56 
Closes #88 