### PR TITLE
Ignore github workflow file in Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,20 +3,11 @@
   "extends": [
     "config:recommended"
   ],
-  "timezone": "UTC",
-  "schedule": [
-    "before 1am on Monday"
+  "ignorePaths": [
+    ".github/workflows/check.yaml",    
+    ".github/workflows/promote.yaml",
+    ".github/workflows/release.yaml"
   ],
-  "labels": [
-    "dependencies",
-    "upstream-release"
-  ],
-  "prConcurrentLimit": 1,
-  "prHourlyLimit": 2,
-  "commitMessagePrefix": "Bump to",
-  "commitMessageAction": "",
-  "commitMessageExtra": "",
-  "commitMessageTopic": "Tailscale {{newVersion}}",
   "customManagers": [
     {
       "customType": "regex",
@@ -29,20 +20,6 @@
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "tailscale/tailscale",
       "extractVersionTemplate": "^v?(?<version>.*)$"
-    }
-  ],
-  "packageRules": [
-    {
-      "matchDatasources": [
-        "github-releases"
-      ],
-      "matchPackageNames": [
-        "tailscale/tailscale"
-      ],
-      "commitMessageTopic": "Tailscale {{newVersion}}",
-      "semanticCommits": "disabled",
-      "automerge": false,
-      "minimumReleaseAge": null
     }
   ]
 }


### PR DESCRIPTION
- Ignore the GitHub workflow file, as it is managed by the automation bot.  
- Remove the commit prefix, which can sometimes cause confusion.  
- Use the default settings for detection.