### PR TITLE
Support no-logs-no-support config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,25 @@ sudo snap unset tailscale https-proxy
 
 The service automatically restarts when proxy settings are changed.
 
+### Disable logging to Tailscale
+
+When using a custom coordination server such as [Headscale](https://github.com/juanfont/headscale), you may want to prevent `tailscaled` from sending logs to Tailscale's infrastructure. To do so:
+
+```
+sudo snap set tailscale no-logs-no-support=true
+```
+
+To re-enable:
+
+```
+sudo snap set tailscale no-logs-no-support=false
+# or
+sudo snap unset tailscale no-logs-no-support
+```
+
+> **Note:** Enabling this option disables Tailscale's technical support. [Ref](https://tailscale.com/docs/install/linux#disable-logging).
+
+
 ## Integration with other snaps
 
 Other snaps can access tailscaled via its unix socket through the `tailscale:socket` slot.

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,5 +1,12 @@
 #!/bin/sh -e
 
+# Validate no-logs-no-support value
+NO_LOGS_NO_SUPPORT="$(snapctl get no-logs-no-support)"
+if [ -n "$NO_LOGS_NO_SUPPORT" ] && [ "$NO_LOGS_NO_SUPPORT" != "true" ] && [ "$NO_LOGS_NO_SUPPORT" != "false" ]; then
+    echo "no-logs-no-support must be 'true' or 'false', got: '${NO_LOGS_NO_SUPPORT}'" >&2
+    exit 1
+fi
+
 # Restart tailscaled service to apply new configuration
 if snapctl services tailscale.tailscaled | grep -q "active"; then
     snapctl restart tailscale.tailscaled

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,10 +1,15 @@
 #!/bin/sh -e
 
-# Validate no-logs-no-support value
-NO_LOGS_NO_SUPPORT="$(snapctl get no-logs-no-support)"
+# Normalise and validate no-logs-no-support value
+NO_LOGS_NO_SUPPORT="$(snapctl get no-logs-no-support | tr '[:upper:]' '[:lower:]')"
 if [ -n "$NO_LOGS_NO_SUPPORT" ] && [ "$NO_LOGS_NO_SUPPORT" != "true" ] && [ "$NO_LOGS_NO_SUPPORT" != "false" ]; then
     echo "no-logs-no-support must be 'true' or 'false', got: '${NO_LOGS_NO_SUPPORT}'" >&2
     exit 1
+fi
+
+# Write back normalised value
+if [ -n "$NO_LOGS_NO_SUPPORT" ]; then
+    snapctl set no-logs-no-support="$NO_LOGS_NO_SUPPORT"
 fi
 
 # Restart tailscaled service to apply new configuration

--- a/snap/local/tailscaled-wrapper.sh
+++ b/snap/local/tailscaled-wrapper.sh
@@ -21,4 +21,13 @@ if [ -n "$NO_PROXY" ]; then
     export no_proxy="$NO_PROXY"
 fi
 
-exec "$SNAP/bin/tailscaled" "$@"
+# Get no-logs-no-support setting
+NO_LOGS_NO_SUPPORT="$(snapctl get no-logs-no-support)"
+
+# Optional flags
+EXTRA_FLAGS=""
+if [ "$NO_LOGS_NO_SUPPORT" = "true" ]; then
+    EXTRA_FLAGS="--no-logs-no-support"
+fi
+
+exec "$SNAP/bin/tailscaled" $EXTRA_FLAGS "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,14 @@ description: |
 
   See https://github.com/canonical/tailscale-snap for more configuration options.
 
+  **Disable Logging**
+
+  When using a custom coordination server (e.g. Headscale), disable logs sent to Tailscale:
+
+  `sudo snap set tailscale no-logs-no-support=true`
+
+  Note: this also disables Tailscale technical support.
+
   **Security**
 
   See https://github.com/canonical/tailscale-snap/blob/main/docs/security-reference.md


### PR DESCRIPTION
Closes #80 

Support `tailscaled` with the flag `no-logs-no-support`. [Ref](https://tailscale.com/docs/reference/tailscaled#flags-to-tailscaled:~:text=%2D%2Dno%2Dlogs%2Dno%2Dsupport) 

This config can now be set/unset via `snap set/unset`. It only accepts values with either `true` or `false` (to prevent unecessary service restart from configure hook if invalid value is provided). The input is case-insensitive (i.e., `true` /`True`/`TRUE` all works - they will be normalised to lowercase).  
 
Follow the upstream setup, by default this flag is not provided to `tailscaled` (equivalent to a `false` set).

**To set** 
```
sudo snap set tailscale no-logs-no-support=true
```
**To disable:**
```
sudo snap set tailscale no-logs-no-support=false
```
or
```
sudo snap unset tailscale no-logs-no-support
```

**Quick test:**
- Provide invalid value:
```
ubuntu@node01:~/tailscale-snap$ sudo snap set tailscale no-logs-no-support=foo
error: cannot perform the following tasks:
- Run configure hook of "tailscale" snap (run hook "configure": no-logs-no-support must be 'true' or 'false', got: 'foo')
```

- Set the config, notice `tailscaled` cmd now includes the flag:
```
ubuntu@node01:~/tailscale-snap$ sudo snap set tailscale no-logs-no-support=true
2026-02-22T14:23:27Z INFO Waiting for "snap.tailscale.tailscaled.service" to stop.
ubuntu@node01:~/tailscale-snap$ systemctl status snap.tailscale.tailscaled.service | head -n 10
● snap.tailscale.tailscaled.service - Service for snap application tailscale.tailscaled
     Loaded: loaded (/etc/systemd/system/snap.tailscale.tailscaled.service; enabled; preset: enabled)
     Active: active (running) since Sun 2026-02-22 14:23:27 UTC; 3min 31s ago
   Main PID: 239397 (tailscaled)
      Tasks: 15 (limit: 38471)
     Memory: 26.3M (peak: 30.4M)
        CPU: 716ms
     CGroup: /system.slice/snap.tailscale.tailscaled.service
             └─239397 /snap/tailscale/x2/bin/tailscaled --no-logs-no-support --socket /var/snap/tailscale/common/socket/tailscaled.sock --statedir /var/snap/tailscale/common --verbose 10
```

- Unset the config, notice `tailscaled` cmd now gets back to default:
```
ubuntu@node01:~/tailscale-snap$ sudo snap unset tailscale no-logs-no-support
ubuntu@node01:~/tailscale-snap$ systemctl status snap.tailscale.tailscaled.service | head -n 10
● snap.tailscale.tailscaled.service - Service for snap application tailscale.tailscaled
     Loaded: loaded (/etc/systemd/system/snap.tailscale.tailscaled.service; enabled; preset: enabled)
     Active: active (running) since Sun 2026-02-22 14:28:11 UTC; 3s ago
   Main PID: 284581 (tailscaled)
      Tasks: 13 (limit: 38471)
     Memory: 31.5M (peak: 31.7M)
        CPU: 577ms
     CGroup: /system.slice/snap.tailscale.tailscaled.service
             └─284581 /snap/tailscale/x2/bin/tailscaled --socket /var/snap/tailscale/common/socket/tailscaled.sock --statedir /var/snap/tailscale/common --verbose 10
```

- Verify the user input gets normalised to lowercase correctly:
```
ubuntu@node01:~$ sudo snap set tailscale no-logs-no-support=True
2026-02-24T22:02:33Z INFO Waiting for "snap.tailscale.tailscaled.service" to stop.
ubuntu@node01:~$ sudo snap get tailscale
Key                 Value
no-logs-no-support  true
ubuntu@node01:~$ sudo snap set tailscale no-logs-no-support=FALSE
ubuntu@node01:~$ sudo snap get tailscale
Key                 Value
no-logs-no-support  false
```